### PR TITLE
Update schema.ts

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -37,7 +37,7 @@ export const accounts = pgTable(
     session_state: text("session_state"),
   },
   (account) => ({
-    compoundKey: primaryKey(account.provider, account.providerAccountId),
+    primaryKey: [account.provider, account.providerAccountId],
   })
 );
 
@@ -57,7 +57,7 @@ export const verificationTokens = pgTable(
     expires: timestamp("expires", { mode: "date" }).notNull(),
   },
   (vt) => ({
-    compoundKey: primaryKey(vt.identifier, vt.token),
+    primaryKey: [vt.identifier, vt.token],
   })
 );
 


### PR DESCRIPTION
make sure you use the last version of drizzle.
There is a new syntax for setting the compoundKey or the composite of the primarykey

here are the versions I am using
    "drizzle-orm": "^0.29.2",
    "drizzle-kit": "^0.20.9",

The syntax you were using is deprecated
